### PR TITLE
Elevate Russia-Iran targeting and sanctions asymmetry as a high-magnitude red flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ Circumstantial evidence is evaluated cumulatively. Timing or association alone i
 - [Counterevidence Attribution Matrix](Tmanch_Conclusion_Attribution_Matrix.csv)
 - [Transatlantic Deterrence and Russia-Pressure Architecture Matrix](Tmanch_CH7_Transatlantic_Pressure_Architecture_Matrix.md)
 - [Russia–China–Iran Targeting and U.S. Casualty Matrix](Tmanch_CH7_Russia_China_Iran_Targeting_Casualty_Matrix.md)
+- [Russia–Iran Targeting and Sanctions High-Magnitude Red-Flag Finding](Tmanch_CH7_Russia_Iran_Sanctions_High_Magnitude_Red_Flag.md)
 - [Source Integrity Audit](SOURCE_INTEGRITY_AUDIT.md)
 
 The active synthesis distinguishes Trump-originated actions from policies imposed or funded by Congress, allies, agencies, military officials, market conditions, or later reversals. It also identifies sanctions and threats that were announced but not implemented, implemented temporarily, or diluted through general licenses and waivers.
 
 The transatlantic matrix distinguishes formal NATO membership and sanctions listings from operational effectiveness. It reweights Article 5 ambiguity, Ukraine-support suspensions, territorial-recognition policy, specialist enforcement dismantling, hybrid-defense reductions, and the domestic beneficial-ownership rollback. Its weighted **55–70 percent** pressure-architecture degradation range is an explicit analytical estimate—not an audited claim that 55–70 percent of statutory sanctions were repealed.
+
+The Russia–Iran high-magnitude red-flag synthesis isolates the combined significance of American casualties, credible Russian targeting support, Trump’s minimization, public reliance on Moscow’s denial, differential punishment of China-based providers, and successive OFAC licenses preserving qualifying Russian-origin oil transactions. It distinguishes targeted sanctions loosening from wholesale repeal while treating the timing and response asymmetry as a controlling Chapter 7 finding.
 
 The active conclusion, TLDR, and source-controlled `J20-Pres.md` contain no fictional-reference or placeholder URLs.
 
@@ -132,6 +135,7 @@ The Chapter 7 expansion covers January 20, 2025 through August 27, 2026. It reco
 - [Counterevidence and hypothesis tests](Tmanch_CH7_counterevidence.md)
 - [Transatlantic Deterrence and Russia-Pressure Architecture Matrix](Tmanch_CH7_Transatlantic_Pressure_Architecture_Matrix.md)
 - [Russia–China–Iran Targeting and U.S. Casualty Matrix](Tmanch_CH7_Russia_China_Iran_Targeting_Casualty_Matrix.md)
+- [Russia–Iran Targeting and Sanctions High-Magnitude Red-Flag Finding](Tmanch_CH7_Russia_Iran_Sanctions_High_Magnitude_Red_Flag.md)
 - [Open questions and records plan](Tmanch_CH7_open_questions.md)
 
 ### `J20-Pres.md` reconciliation package

--- a/Tmanch_CH7_Russia_Iran_Sanctions_High_Magnitude_Red_Flag.md
+++ b/Tmanch_CH7_Russia_Iran_Sanctions_High_Magnitude_Red_Flag.md
@@ -1,0 +1,262 @@
+# Russia–Iran Targeting and Sanctions Asymmetry
+## High-Magnitude Red-Flag Finding for Chapter 7 and the Working Conclusion
+### Coverage: March 1–August 27, 2026
+
+> **Analytical status:** Controlling synthesis of the Russia–Iran targeting, U.S.-casualty, presidential-response, and Russian-oil licensing chronology.  
+> **Companion record:** [Russia–China–Iran Targeting and U.S. Casualty Matrix](Tmanch_CH7_Russia_China_Iran_Targeting_Casualty_Matrix.md) · [OFAC License Matrix](Tmanch_CH7_OFAC_license_matrix.csv) · [Chapter 7](Tmanch_CH7.md) · [Working Conclusion](Current_Working_Tmanch_Conclusion.md)
+
+---
+
+# 1. Why this is a high-magnitude red flag
+
+This sequence is qualitatively different from most of the repository’s Russia-policy evidence.
+
+It does not concern only:
+
+- NATO burden sharing;
+- Ukraine policy;
+- sanctions enforcement;
+- election interference;
+- oligarch wealth;
+- diplomatic language;
+- or commercial conflicts.
+
+It concerns credible reporting that Russia supplied operational targeting assistance to Iran during attacks that **killed and wounded American service members**, followed by:
+
+- presidential minimization of the Russian role;
+- public elevation of Moscow’s denial;
+- no identified public Russia-specific penalty tied to the targeting assistance;
+- continued high-level diplomacy;
+- and successive OFAC licenses preserving qualifying Russian-origin oil transactions and revenue pathways.
+
+The high-magnitude red flag is not any one item in isolation. It is the combination:
+
+> **American casualties + credible Russian targeting support + presidential minimization + differential attribution and punishment + contemporaneous Russian economic relief.**
+
+---
+
+# 2. Controlling chronology
+
+| Date | Event | Evidentiary status | Analytical significance |
+|---|---|---|---|
+| **March 1, 2026** | Iranian unmanned aircraft attack at Port Shuaiba, Kuwait, killed six U.S. Army Reserve soldiers and wounded additional personnel | **Established by U.S. military records** | Converts the issue from abstract foreign-policy alignment into an American-casualty question |
+| **March 5** | OFAC issued General License 133 authorizing specified delivery and sale transactions involving Russian-origin oil cargoes to India | **Established by OFAC record** | Preserved qualifying Russian oil transaction and revenue pathways during the regional war |
+| **March 6** | Reporting based on officials familiar with U.S. intelligence said Russia supplied Iran information concerning U.S. warships, aircraft, and military assets | **Strong intelligence-based documentary reporting; Russia denies it** | Places Russian support inside the same lethal campaign against American forces |
+| **March 7** | After attending the dignified transfer for the six soldiers killed in Kuwait, Trump minimized the reported Russian assistance and resisted treating it as a major rupture | **Established public response** | Demonstrates exceptional presidential restraint toward Russia despite direct U.S. military harm |
+| **March 10** | Witkoff said Putin and Yuri Ushakov denied the assistance and that the United States could take them at their word, while acknowledging that intelligence agencies should assess it | **Established attributed statement** | Elevated the accused state’s denial while the U.S. intelligence issue remained unresolved |
+| **March 12** | OFAC issued General License 134 authorizing specified delivery and sale of Russian-origin crude and petroleum products | **Established by OFAC record** | Continued economic authorization after the Russian-targeting allegation was public |
+| **March 19** | OFAC issued General License 134A | **Established by OFAC record** | Extended or amended the Russian-origin oil authorization after the public allegation and Russian denial |
+| **March 21–31** | A later intelligence assessment described at least 24 Russian reconnaissance surveys covering 46 military and infrastructure targets in 11 countries, with Iranian strikes reportedly following collection in multiple cases | **Reuters-reviewed intelligence assessment with partial corroboration; Russia denies it** | Provides a collection-to-strike chronology beyond a generalized allegation |
+| **March 27–28** | Russian collection reportedly preceded an Iranian strike damaging a U.S. E-3 Sentry AWACS aircraft at Prince Sultan Air Base, followed by post-strike collection | **Strong target-specific intelligence reporting; exact product and dissemination remain nonpublic** | Shows a concrete U.S. target chain capable of being tested against classified records |
+| **April 17** | OFAC issued General License 134B | **Established by OFAC record** | Continued Russian oil authorization after detailed satellite and cyber-support reporting |
+| **May 8** | The United States publicly sanctioned named China-based geospatial companies and an Iranian intermediary for imagery that enabled Iranian attacks on U.S. forces | **Official U.S. attribution and sanctions action** | Creates a direct comparator for the visible treatment of Russian support |
+| **May 18** | OFAC issued General License 134C | **Established by OFAC record** | Preserved qualifying Russian oil pathways after the United States publicly punished China-based providers |
+| **August 27** | When asked about punishing countries doing business with Iran, Trump said Russia had behaved “quite well” concerning the Strait of Hormuz | **Established attributed public statement** | Shows that the targeting controversy did not produce a durable public presumption that Russia was acting as a hostile power |
+
+---
+
+# 3. The sanctions point must be stated precisely
+
+The administration did **not** repeal the entire Russia sanctions regime during this period.
+
+The administration did:
+
+- issue multiple general licenses authorizing transactions that would otherwise have been prohibited;
+- preserve delivery, sale, settlement, shipping, insurance, banking, or related pathways for qualifying Russian-origin cargoes;
+- extend those authorizations after the targeting allegation became public;
+- continue them after more detailed Russian satellite-support reporting;
+- and continue them after the United States publicly sanctioned China-based providers for enabling attacks on American forces.
+
+The correct terminology is therefore:
+
+> **targeted sanctions loosening and transaction authorization with material Russian economic benefit—not wholesale sanctions repeal.**
+
+The licenses had plausible and potentially substantial U.S. rationales:
+
+- managing an energy shock;
+- stabilizing prices;
+- protecting allied or partner economies;
+- avoiding supply disruption;
+- and permitting orderly settlement of cargoes already loaded.
+
+Those rationales affect motive. They do not erase the economic effect or the extraordinary chronology.
+
+---
+
+# 4. Differential-treatment matrix
+
+| Question | China-based providers | Russia | Analytical consequence |
+|---|---|---|---|
+| Was enabling targeting support publicly attributed? | **Yes.** Named companies and intermediary were identified in U.S. action | **Credibly reported through U.S. intelligence sources and later collection-to-strike reporting; Russia denied it** | Evidence posture differed, but the Russian allegation was serious and operationally specific |
+| Was there an identified public consequence tied to targeting support? | **Yes.** Public sanctions | **No equivalent public Russia-specific sanction tied to the targeting assistance has been identified** | Creates a visible consequence asymmetry |
+| Did the president publicly minimize the conduct? | No comparable presidential minimization located | **Yes** | Russia received exceptional rhetorical insulation |
+| Was the accused actor’s denial publicly elevated? | Not comparably | **Yes. Putin and Ushakov’s denials were repeated through Witkoff** | Russian assurances were granted unusual public weight |
+| Did economically beneficial transaction authority continue? | Not the relevant channel | **Yes. GL 133 and 134 series preserved qualifying Russian-origin oil transactions** | Economic relief and threat minimization occurred in the same evidentiary period |
+| Did diplomacy visibly rupture? | Not applicable in the same way | **No. High-level engagement continued** | Russia was not publicly moved into a clearly hostile category despite the allegation |
+
+This comparison does not prove that the evidence against China-based companies and Russia was identical. Official designation packages may have contained different levels of proof, attribution confidence, or legal sufficiency.
+
+It establishes that the **visible response architecture was sharply different**.
+
+---
+
+# 5. Why ordinary restraint does not fully explain the pattern
+
+A conventional explanation is available:
+
+- the United States was already fighting Iran and wished to avoid a second confrontation;
+- intelligence remained classified and contested;
+- Russia denied the allegation;
+- public attribution could expose sources and methods;
+- oil licenses served urgent market-stability needs;
+- and quiet diplomatic, intelligence, cyber, or covert consequences may have occurred.
+
+Those considerations are legitimate.
+
+They do not fully explain why the public response contained so many Russia-protective features at once:
+
+1. minimization immediately after American deaths;
+2. repetition of Moscow’s denial;
+3. no identified public warning tied specifically to targeting Americans;
+4. no identified public Russia-specific sanction tied to the assistance;
+5. continued diplomatic trust framing;
+6. successive oil authorizations after public disclosure;
+7. public punishment of China-based providers for analogous enabling support; and
+8. later praise of Russian behavior concerning Iran.
+
+A restrained president could avoid escalation while still saying:
+
+> Helping Iran target American forces is unacceptable, the intelligence will be fully investigated, and any responsible Russian entity will face consequences.
+
+The public record instead shows a substantially softer posture.
+
+---
+
+# 6. Knowledge and causation ladder
+
+## Established
+
+- Iran attacked U.S. forces.
+- American service members were killed and wounded.
+- China-based geospatial providers were publicly sanctioned for imagery enabling strikes against U.S. forces.
+- Trump minimized reported Russian targeting assistance.
+- Russian officials denied the assistance.
+- OFAC issued and extended the identified Russian-origin oil licenses.
+
+## Strongly supported but not fully declassified
+
+- Russia supplied Iran information concerning American military assets.
+- Russian satellite collection preceded multiple Iranian strikes.
+- Russian imagery and cyber support improved Iranian operational capability.
+
+## Not publicly established
+
+- the exact Russian product used for the Port Shuaiba strike;
+- casualty-by-casualty causation;
+- Putin’s personal approval of each intelligence transfer;
+- Trump’s complete classified briefing record;
+- whether the licenses were issued because of any promise to Russia;
+- whether classified or covert consequences were imposed;
+- or an explicit bargain protecting Russia from retaliation.
+
+The absence of casualty-specific proof prevents a homicide-style causal claim. It does not make the targeting support or response asymmetry insignificant.
+
+---
+
+# 7. Counterintelligence significance
+
+A president’s threat hierarchy is revealed most clearly when interests collide.
+
+Here, the collision involved:
+
+- the safety and deaths of American service members;
+- a major foreign-policy relationship with Russia;
+- energy prices and supply stability;
+- classified intelligence attribution;
+- and the administration’s desire to preserve direct diplomacy with Putin.
+
+The observed choice was not full confrontation with Russia. It was:
+
+- minimization;
+- acceptance or repetition of Russian denials;
+- continued diplomacy;
+- no identified public targeting-related Russia penalty;
+- and continued authorization of qualifying Russian oil transactions.
+
+That does not prove formal control.
+
+It is strong outcome evidence that Russia occupied an unusually protected position even when the alleged Russian conduct reached the core commander-in-chief responsibility of protecting American forces.
+
+---
+
+# 8. High-magnitude red-flag finding
+
+> **This sequence is one of the strongest single red flags in the entire project. Russian state-linked targeting support was credibly reported during a lethal Iranian campaign against American forces. The United States publicly punished named China-based providers for analogous enabling support, but Trump minimized the Russian allegation, elevated Moscow’s denial, preserved high-level engagement, and continued successive licenses that maintained qualifying Russian-origin oil transactions. The public record does not establish which Russian intelligence product caused each casualty, nor does it prove an explicit agreement to protect Russia. It does establish an exceptional asymmetry in attribution, outrage, consequences, and economic treatment at the precise moment Russian conduct was credibly linked to threats against American lives.**
+
+---
+
+# 9. Conclusion-ready language
+
+> **The Russia–Iran targeting relationship is not merely another Russia-favorable policy dispute. It involves credible intelligence that Russia helped Iran locate American military assets during attacks that killed and wounded U.S. service members. Trump publicly minimized the reported assistance, gave unusual weight to Moscow’s denial, did not announce a comparable Russia-specific consequence, and presided over successive general licenses preserving qualifying Russian oil transactions after the allegation became public. Those licenses had defensible energy-market purposes and did not repeal the broader sanctions regime. But their timing, combined with the administration’s contrasting public sanctions against China-based targeting providers, creates a high-magnitude red flag: Russia remained unusually insulated from presidential attribution and sustained consequence even when its reported conduct directly threatened American personnel.**
+
+---
+
+# 10. Records required to resolve the issue
+
+## Intelligence and military
+
+- complete U.S. intelligence assessment;
+- source-reporting chronology;
+- satellite tasking and imagery metadata;
+- dissemination records to Iranian recipients;
+- communications intercepts;
+- strike-package and target-development records;
+- Port Shuaiba investigation;
+- Prince Sultan Air Base damage and warning assessment;
+- and any captured Iranian targeting materials.
+
+## Presidential and diplomatic
+
+- President’s Daily Brief items;
+- National Security Council options memoranda;
+- Trump–Putin call memorandum;
+- Witkoff/Kushner–Ushakov meeting notes;
+- presidential talking points and briefing records;
+- diplomatic demarches;
+- sanctions and retaliation options;
+- and any classified or covert response directive.
+
+## Treasury and energy
+
+- GL 133 and 134-series decision memoranda;
+- date each decision-maker learned of the targeting intelligence;
+- cargo values and counterparties;
+- estimated Russian revenue and fiscal benefit;
+- alternative supply analyses;
+- White House, NSC, Treasury, Energy, and State communications;
+- and records explaining why each extension remained necessary after additional disclosures.
+
+## Comparative attribution
+
+- designation evidentiary packages for the China-based providers;
+- legal and intelligence thresholds applied to Russia;
+- Russia-specific options that were rejected, delayed, or handled nonpublicly;
+- and comparative assessments of escalation, evidence confidence, and source protection.
+
+---
+
+# 11. Principal sources
+
+- U.S. Army Reserve casualty confirmation: https://www.usar.army.mil/News/Article/4431227/media-release-army-reserve-confirms-casualty/
+- CENTCOM casualty and operational update: https://www.centcom.mil/MEDIA/STATEMENTS/Statements-View/Article/4418924/operation-epic-fury-update/
+- Washington Post on Russian targeting support: https://www.washingtonpost.com/national-security/2026/03/06/russia-iran-intelligence-us-targets/
+- Associated Press on Trump’s minimization: https://apnews.com/article/iran-russia-intelligence-sharing-trump-oil-prices-109923968208e549fe1d674d7cb71978
+- Reuters on Russian denial and Witkoff: https://www.reuters.com/world/middle-east/russia-told-trump-it-isnt-sharing-us-military-asset-info-with-iran-says-witkoff-2026-03-10/
+- Reuters on Russian satellite and cyber support: https://www.reuters.com/world/europe/russia-supplies-iran-with-cyber-support-spy-imagery-hone-attacks-ukraine-says-2026-04-07/
+- U.S.–China Economic and Security Review Commission timeline: https://www.uscc.gov/research/enabling-iran-timeline-chinas-role-during-and-after-operation-epic-fury
+- OFAC GL 133: https://ofac.treasury.gov/recent-actions/20260305_33
+- OFAC GL 134: https://ofac.treasury.gov/recent-actions/20260312_33
+- OFAC GL 134A: https://ofac.treasury.gov/recent-actions/20260319_33
+- OFAC GL 134B: https://ofac.treasury.gov/recent-actions/20260417_33
+- OFAC GL 134C: https://ofac.treasury.gov/recent-actions/20260518_33
+- Reuters on August 27 remarks: https://www.reuters.com/world/middle-east/trump-says-us-is-not-talking-with-iran-economic-war-focus-2026-08-27/


### PR DESCRIPTION
## What changed

This PR elevates the Russia–Iran targeting, American-casualty, presidential-response, and Russian-oil licensing chronology into a stand-alone controlling synthesis rather than leaving the finding distributed across Chapter 7, the casualty matrix, and the OFAC ledger.

### New supporting document

Adds `Tmanch_CH7_Russia_Iran_Sanctions_High_Magnitude_Red_Flag.md`, which consolidates:

- six U.S. Army Reserve deaths and additional injuries at Port Shuaiba;
- credible reporting that Russia supplied Iran information concerning U.S. military assets;
- the Russian satellite collection-to-strike chronology and Prince Sultan/AWACS sequence;
- official U.S. sanctions against China-based geospatial providers for enabling attacks on U.S. forces;
- Trump’s minimization of the Russian allegation after the dignified transfer;
- public elevation of Putin and Ushakov’s denials;
- the absence of an identified public Russia-specific targeting penalty;
- General Licenses 133, 134, 134A, 134B, and 134C;
- Trump’s August 27 statement that Russia had behaved “quite well” concerning the Strait of Hormuz;
- alternative explanations, evidentiary limits, falsification criteria, and a records plan.

### Precise sanctions finding

The document distinguishes **targeted sanctions loosening and transaction authorization with material Russian economic benefit** from wholesale repeal of the Russia sanctions regime.

### Controlling finding

> American casualties + credible Russian targeting support + presidential minimization + differential attribution and punishment + contemporaneous Russian economic relief constitute one of the strongest single red flags in the project.

### Repository index

Updates `README.md` to link and describe the new controlling Chapter 7 synthesis.

## Validation

- 2 commits ahead of `main`
- 2 files changed
- 266 additions
- Documentation only
